### PR TITLE
webidl and load testing: help needed -> inactive projects

### DIFF
--- a/Projects/WebIDL
+++ b/Projects/WebIDL
@@ -2,7 +2,7 @@
 title: WebIDL
 author: [David Sheets](https://github.com/dsheets/)
 abstract: develop WebIDL library from scratch
-tags: help needed, http, web
+tags: inactive project, http, web
 ---
 
 The modern web is becoming an application platform in addition to its

--- a/Projects/load
+++ b/Projects/load
@@ -1,7 +1,7 @@
 ---
 author: djs55 ([David Scott](https://github.com/djs55))
 title: tiny VM for easy load testing
-tags: active project, help needed
+tags: inactive project
 ---
 
 ### Create a tiny VM for easy load testing


### PR DESCRIPTION
"inactive projects" might not be the best name; others welcome.

@djs55 and @dsheets indicated that they didn't have time to mentor these projects, so it seems best to at least remove then from `help needed`. 